### PR TITLE
feat: Make static gitlab_runner params tunable

### DIFF
--- a/tasks/single-runner.yml
+++ b/tasks/single-runner.yml
@@ -8,11 +8,11 @@
   block:
     - name: Ensure the runner is registered
       community.general.gitlab_runner:
-        access_level: not_protected
-        active: true
-        locked: false
-        run_untagged: true
-        state: present
+        access_level: "{{ item.access_level | default('not_protected') }}"
+        active: "{{ item.active | default(omit) }}"
+        locked: "{{ item.locked | default(omit) }}"
+        run_untagged: "{{ item.run_untagged | default(omit) }}"
+        state: "{{ item.state | default(omit) }}"
         api_url: "{{ item.gitlab_url }}"
         api_token: "{{ gitlab_runner_api_token }}"
         description: "{{ item.description | default(inventory_hostname) }}"
@@ -20,7 +20,7 @@
         project: "{{ item.project is defined | ternary(runner_target, omit) }}"
         tag_list: "{{ item.tags | default([]) + [inventory_hostname] }}"
         registration_token: "{{ item.registration_token }}"
-        validate_certs: false
+        validate_certs: "{{ item.validate_certs | default('false') }}"
       register: runner_register
     - name: Define runner config snippet
       ansible.builtin.set_fact:


### PR DESCRIPTION
Do not enforce values. Whenever the previously configured value was the default of module community.general.gitlab_runner, fallback to the default behaviour with `omit`.