### PR TITLE
feat: Add group parameter to gitlab_runner

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY-4.0
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: '2.15'
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/single-runner.yml
+++ b/tasks/single-runner.yml
@@ -17,6 +17,7 @@
         api_token: "{{ gitlab_runner_api_token }}"
         description: "{{ item.description | default(inventory_hostname) }}"
         maximum_timeout: "{{ item.maximum_timeout | default(omit) }}"
+        group: "{{ item.group is defined | ternary(runner_target, omit) }}"
         project: "{{ item.project is defined | ternary(runner_target, omit) }}"
         tag_list: "{{ item.tags | default([]) + [inventory_hostname] }}"
         registration_token: "{{ item.registration_token }}"


### PR DESCRIPTION
This parameter was removed in commit 462ef4ec because it was not yet supported by community.general < 6.5.0. This is now fixed, so we can add this parameter back.