### PR TITLE
Allow registration token depreciation

### DIFF
--- a/tasks/single-runner.yml
+++ b/tasks/single-runner.yml
@@ -20,7 +20,7 @@
         group: "{{ item.group is defined | ternary(runner_target, omit) }}"
         project: "{{ item.project is defined | ternary(runner_target, omit) }}"
         tag_list: "{{ item.tags | default([]) + [inventory_hostname] }}"
-        registration_token: "{{ item.registration_token }}"
+        registration_token: "{{ item.registration_token | default(omit) }}"
         validate_certs: "{{ item.validate_certs | default('false') }}"
       register: runner_register
     - name: Define runner config snippet


### PR DESCRIPTION
Registering a runner with a registration token is now deprecated : https://docs.gitlab.com/runner/register/#register-with-a-runner-registration-token-deprecated
We need to be able to register a runner without one
See https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_runner_module.html