### PR TITLE
Allow break_system_packages var for python-gitlab pip package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
     name: python-gitlab
     state: present
     extra_args: --user
+    break_system_packages: "{{ gitlab_runner_break_system_packages | default(omit) }}"
 
 - name: Install python-gitlab with the package manager
   when: gitlab_runner_package_manager != 'pip'


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pip_module.html#parameter-break_system_packages

Since the package is not installed in a virtual environment, we need to set this var to `true`.
The `ansible.builtin.pip` default is `false`.
I could also set a static `break_system_packages: true` since the context won't change, use `| default(true)` or even create a default var, as you prefer.