### PR TITLE
feat: add timezone environment variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,5 @@ gitlab_runner_package_manager: pip
 #     registration_token: mysecureprojecttoken
 #   - gitlab_url: https://my.gitlab.url
 #     registration_token: mysecureinstancetoken
+
+timezone_name: "America/Toronto"

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -3,6 +3,8 @@ services:
   runner:
     image: gitlab/gitlab-runner:{{ gitlab_runner_version }}
     container_name: {{ gitlab_runner_container_name }}
+    environment:
+      TZ: {{ timezone_name }}
     restart: always
     volumes:
       - ./conf:/etc/gitlab-runner


### PR DESCRIPTION
Added the TZ variable to the environment configuration using `{{ timezone_name }}`. 
This ensures gitlab-runner to use the correct local time for scheduled tasks.